### PR TITLE
use django-cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ pymysql
 sshtunnel
 django-instagram
 cairosvg
+django-cleanup

--- a/weitblick/settings.py
+++ b/weitblick/settings.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = [
     'cookielaw',
     'django.contrib.humanize',
     'captcha',
+    'django_cleanup.apps.CleanupConfig',  # should be at the bottom
 ]
 
 AUTH_USER_MODEL = 'wbcore.User'


### PR DESCRIPTION
use django-cleanup (needs to be installed) https://github.com/un1t/django-cleanup

This deletes the file corresponding to FileField and ImageFields when the database entry is deleted. It therefore fixes #70 

Photologue images referenced in e.g. news-posts are obviously not handled by this (as they are no FileField in the NewsPost model). For this #140 is still open.