### PR TITLE
215 linked documents

### DIFF
--- a/wbcore/admin.py
+++ b/wbcore/admin.py
@@ -25,7 +25,7 @@ from itertools import chain
 
 from .models import (
     Address, Location, Host, Partner, Project, Event, NewsPost, BlogPost, ContactMessage, UserRelation,
-    Document, Team, Milestone, Donation, BankAccount, TeamUserRelation, Content, User, JoinPage,
+    Document, ExternalDocument, Team, Milestone, Donation, BankAccount, TeamUserRelation, Content, User, JoinPage,
     SocialMediaLink, CycleDonation, QuestionAndAnswer, FAQ, Photo)
 
 
@@ -734,6 +734,9 @@ class DocumentAdmin(MyAdmin):
 
     list_display = ('title', 'host', 'document_type', 'published', 'public', 'valid_from')
 
+class ExternalDocumentAdmin(MyAdmin):
+
+    list_display = ('title', 'host', 'document_type', 'published', 'public', 'valid_from')
 
 class DonationAdmin(MyAdmin):
 
@@ -838,6 +841,7 @@ admin.site.register(ContactMessage, ContactMessageAdmin)
 admin.site.register(Content, ContentAdmin)
 admin.site.register(CycleDonation, CycleDonationAdmin)
 admin.site.register(Document, DocumentAdmin)
+admin.site.register(ExternalDocument, ExternalDocumentAdmin)
 admin.site.register(Donation, DonationAdmin)
 admin.site.register(Event, EventAdmin)
 admin.site.register(FAQ, FAQAdmin)

--- a/wbcore/admin.py
+++ b/wbcore/admin.py
@@ -25,7 +25,7 @@ from itertools import chain
 
 from .models import (
     Address, Location, Host, Partner, Project, Event, NewsPost, BlogPost, ContactMessage, UserRelation,
-    Document, ExternalDocument, Team, Milestone, Donation, BankAccount, TeamUserRelation, Content, User, JoinPage,
+    Document, UrlDocument, Team, Milestone, Donation, BankAccount, TeamUserRelation, Content, User, JoinPage,
     SocialMediaLink, CycleDonation, QuestionAndAnswer, FAQ, Photo)
 
 
@@ -730,13 +730,18 @@ class CycleDonationAdmin(MyAdmin):
     get_projects.short_description = 'Projects'
 
 
-class DocumentAdmin(MyAdmin):
+class BaseDocumentAdmin(MyAdmin):
 
     list_display = ('title', 'host', 'document_type', 'published', 'public', 'valid_from')
 
-class ExternalDocumentAdmin(MyAdmin):
 
-    list_display = ('title', 'host', 'document_type', 'published', 'public', 'valid_from')
+class DocumentAdmin(BaseDocumentAdmin):
+    fields = ('title', 'description', 'host', 'file', 'valid_from', 'document_type', 'public')
+
+
+class UrlDocumentAdmin(BaseDocumentAdmin):
+    fields = ('title', 'description', 'host', 'url', 'valid_from', 'document_type', 'public')
+
 
 class DonationAdmin(MyAdmin):
 
@@ -841,7 +846,7 @@ admin.site.register(ContactMessage, ContactMessageAdmin)
 admin.site.register(Content, ContentAdmin)
 admin.site.register(CycleDonation, CycleDonationAdmin)
 admin.site.register(Document, DocumentAdmin)
-admin.site.register(ExternalDocument, ExternalDocumentAdmin)
+admin.site.register(UrlDocument, UrlDocumentAdmin)
 admin.site.register(Donation, DonationAdmin)
 admin.site.register(Event, EventAdmin)
 admin.site.register(FAQ, FAQAdmin)

--- a/wbcore/admin.py
+++ b/wbcore/admin.py
@@ -25,7 +25,7 @@ from itertools import chain
 
 from .models import (
     Address, Location, Host, Partner, Project, Event, NewsPost, BlogPost, ContactMessage, UserRelation,
-    Document, UrlDocument, Team, Milestone, Donation, BankAccount, TeamUserRelation, Content, User, JoinPage,
+    Document, LinkedDocument, Team, Milestone, Donation, BankAccount, TeamUserRelation, Content, User, JoinPage,
     SocialMediaLink, CycleDonation, QuestionAndAnswer, FAQ, Photo)
 
 
@@ -739,7 +739,7 @@ class DocumentAdmin(BaseDocumentAdmin):
     fields = ('title', 'description', 'host', 'file', 'valid_from', 'document_type', 'public')
 
 
-class UrlDocumentAdmin(BaseDocumentAdmin):
+class LinkedDocumentAdmin(BaseDocumentAdmin):
     fields = ('title', 'description', 'host', 'url', 'valid_from', 'document_type', 'public')
 
 
@@ -846,7 +846,7 @@ admin.site.register(ContactMessage, ContactMessageAdmin)
 admin.site.register(Content, ContentAdmin)
 admin.site.register(CycleDonation, CycleDonationAdmin)
 admin.site.register(Document, DocumentAdmin)
-admin.site.register(UrlDocument, UrlDocumentAdmin)
+admin.site.register(LinkedDocument, LinkedDocumentAdmin)
 admin.site.register(Donation, DonationAdmin)
 admin.site.register(Event, EventAdmin)
 admin.site.register(FAQ, FAQAdmin)

--- a/wbcore/models.py
+++ b/wbcore/models.py
@@ -888,6 +888,7 @@ class BaseDocument(RulesModel):
 
 class Document(BaseDocument):
     file = models.FileField(upload_to=save_document)
+    icon = 'file pdf outline'
 
     def get_url(self):
         return self.file.url
@@ -895,6 +896,7 @@ class Document(BaseDocument):
 
 class UrlDocument(BaseDocument):
     url = models.URLField()
+    icon = 'linkify'
 
     def get_url(self):
         return self.url

--- a/wbcore/models.py
+++ b/wbcore/models.py
@@ -885,6 +885,43 @@ class Document(RulesModel):
     def get_hosts(self):
         return [self.host]
 
+    def get_url(self):
+        return self.file.url
+
+class ExternalDocument(RulesModel):
+    class Meta:
+        rules_permissions = {
+            "add": pred.is_super_admin | pred.is_admin | pred.is_editor,
+            "view": pred.is_super_admin | pred.is_admin | pred.is_editor,
+            "change": pred.is_super_admin | pred.is_admin | pred.is_editor,
+            "delete": pred.is_super_admin | pred.is_admin | pred.is_editor,
+        }
+        get_latest_by = 'valid_from'
+
+    title = models.CharField(max_length=50)
+    description = models.TextField(null=True, blank=True)
+    url = models.URLField()
+    host = models.ForeignKey(Host, on_delete=models.SET_NULL, null=True)
+    published = models.DateTimeField(auto_now_add=True, blank=True, null=True)
+    TYPE_CHOICES = Document.TYPE_CHOICES
+    document_type = models.CharField(max_length=40, choices=TYPE_CHOICES, default='annual_report', null=True)
+    updated = models.DateTimeField(auto_now=True, blank=True, null=True)
+    valid_from = models.DateField(blank=False, default=datetime.date.today)
+    public = models.BooleanField(default=True)
+
+    def belongs_to_host(self, host):
+        return self.host == host
+
+    def __str__(self):
+        city = ("(" + self.host.city + ")") if self.host else ''
+        return self.title + " " + city
+
+    def get_hosts(self):
+        return [self.host]
+
+    def get_url(self):
+        return self.url
+
 
 class Team(RulesModel):
     class Meta:

--- a/wbcore/models.py
+++ b/wbcore/models.py
@@ -848,7 +848,7 @@ def save_document(instance, filename):
     return replace_umlaute(path)
 
 
-class Document(RulesModel):
+class BaseDocument(RulesModel):
     class Meta:
         rules_permissions = {
             "add": pred.is_super_admin | pred.is_admin | pred.is_editor,
@@ -857,10 +857,10 @@ class Document(RulesModel):
             "delete": pred.is_super_admin | pred.is_admin | pred.is_editor,
         }
         get_latest_by = 'valid_from'
+        abstract = True
 
     title = models.CharField(max_length=50)
     description = models.TextField(null=True, blank=True)
-    file = models.FileField(upload_to=save_document)
     host = models.ForeignKey(Host, on_delete=models.SET_NULL, null=True)
     published = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     TYPE_CHOICES = (
@@ -885,39 +885,16 @@ class Document(RulesModel):
     def get_hosts(self):
         return [self.host]
 
+
+class Document(BaseDocument):
+    file = models.FileField(upload_to=save_document)
+
     def get_url(self):
         return self.file.url
 
-class ExternalDocument(RulesModel):
-    class Meta:
-        rules_permissions = {
-            "add": pred.is_super_admin | pred.is_admin | pred.is_editor,
-            "view": pred.is_super_admin | pred.is_admin | pred.is_editor,
-            "change": pred.is_super_admin | pred.is_admin | pred.is_editor,
-            "delete": pred.is_super_admin | pred.is_admin | pred.is_editor,
-        }
-        get_latest_by = 'valid_from'
 
-    title = models.CharField(max_length=50)
-    description = models.TextField(null=True, blank=True)
+class UrlDocument(BaseDocument):
     url = models.URLField()
-    host = models.ForeignKey(Host, on_delete=models.SET_NULL, null=True)
-    published = models.DateTimeField(auto_now_add=True, blank=True, null=True)
-    TYPE_CHOICES = Document.TYPE_CHOICES
-    document_type = models.CharField(max_length=40, choices=TYPE_CHOICES, default='annual_report', null=True)
-    updated = models.DateTimeField(auto_now=True, blank=True, null=True)
-    valid_from = models.DateField(blank=False, default=datetime.date.today)
-    public = models.BooleanField(default=True)
-
-    def belongs_to_host(self, host):
-        return self.host == host
-
-    def __str__(self):
-        city = ("(" + self.host.city + ")") if self.host else ''
-        return self.title + " " + city
-
-    def get_hosts(self):
-        return [self.host]
 
     def get_url(self):
         return self.url

--- a/wbcore/models.py
+++ b/wbcore/models.py
@@ -894,7 +894,7 @@ class Document(BaseDocument):
         return self.file.url
 
 
-class UrlDocument(BaseDocument):
+class LinkedDocument(BaseDocument):
     url = models.URLField()
     icon = 'linkify'
 

--- a/wbcore/templates/wbcore/document_list.html
+++ b/wbcore/templates/wbcore/document_list.html
@@ -6,7 +6,7 @@
             <tr>
                 {% if show_year %}<td class="one wide">{{ document.valid_from.year }}</td>{% endif %}
                 <td class="selectable">
-                    <a target="_blank" href="{{ document.get_url }}" > <i class="file pdf outline icon"></i>{{ document.title }} </a>
+                    <a target="_blank" href="{{ document.get_url }}" > <i class="{{ document.icon }} icon"></i>{{ document.title }} </a>
                 </td>
             </tr>
         {% endfor %}

--- a/wbcore/templates/wbcore/document_list.html
+++ b/wbcore/templates/wbcore/document_list.html
@@ -6,7 +6,7 @@
             <tr>
                 {% if show_year %}<td class="one wide">{{ document.valid_from.year }}</td>{% endif %}
                 <td class="selectable">
-                    <a target="_blank" href="{{ document.file.url }}" > <i class="file pdf outline icon"></i>{{ document.title }} </a>
+                    <a target="_blank" href="{{ document.get_url }}" > <i class="file pdf outline icon"></i>{{ document.title }} </a>
                 </td>
             </tr>
         {% endfor %}

--- a/wbcore/translation.py
+++ b/wbcore/translation.py
@@ -6,7 +6,7 @@ Necessary for the modeltranslation package
 
 from modeltranslation.translator import register, TranslationOptions
 from .models import (
-    Project, Location, Address, Host, Partner, NewsPost, BlogPost, Document, UrlDocument, Team, Content, Event, Milestone,
+    Project, Location, Address, Host, Partner, NewsPost, BlogPost, Document, LinkedDocument, Team, Content, Event, Milestone,
     Donation, BankAccount, ContactMessage, CycleDonation, FAQ, QuestionAndAnswer, UserRelation, JoinPage,
     SocialMediaLink, TeamUserRelation, CycleDonationRelation, Photo)
 from schedule.models.events import Event as ScheduleEvent
@@ -62,8 +62,8 @@ class DocumentTranslationOptions(TranslationOptions):
     fields = ('title','description')
 
 
-@register(UrlDocument)
-class UrlDocumentTranslationOptions(TranslationOptions):
+@register(LinkedDocument)
+class LinkedDocumentTranslationOptions(TranslationOptions):
     fields = ('title','description')
 
 

--- a/wbcore/translation.py
+++ b/wbcore/translation.py
@@ -63,7 +63,7 @@ class DocumentTranslationOptions(TranslationOptions):
 
 
 @register(UrlDocument)
-class ExternalDocumentTranslationOptions(TranslationOptions):
+class UrlDocumentTranslationOptions(TranslationOptions):
     fields = ('title','description')
 
 

--- a/wbcore/translation.py
+++ b/wbcore/translation.py
@@ -6,7 +6,7 @@ Necessary for the modeltranslation package
 
 from modeltranslation.translator import register, TranslationOptions
 from .models import (
-    Project, Location, Address, Host, Partner, NewsPost, BlogPost, Document, Team, Content, Event, Milestone,
+    Project, Location, Address, Host, Partner, NewsPost, BlogPost, Document, ExternalDocument, Team, Content, Event, Milestone,
     Donation, BankAccount, ContactMessage, CycleDonation, FAQ, QuestionAndAnswer, UserRelation, JoinPage,
     SocialMediaLink, TeamUserRelation, CycleDonationRelation, Photo)
 from schedule.models.events import Event as ScheduleEvent
@@ -59,6 +59,11 @@ class BlogPostTranslationOptions(TranslationOptions):
 
 @register(Document)
 class DocumentTranslationOptions(TranslationOptions):
+    fields = ('title','description')
+
+
+@register(ExternalDocument)
+class ExternalDocumentTranslationOptions(TranslationOptions):
     fields = ('title','description')
 
 

--- a/wbcore/translation.py
+++ b/wbcore/translation.py
@@ -6,7 +6,7 @@ Necessary for the modeltranslation package
 
 from modeltranslation.translator import register, TranslationOptions
 from .models import (
-    Project, Location, Address, Host, Partner, NewsPost, BlogPost, Document, ExternalDocument, Team, Content, Event, Milestone,
+    Project, Location, Address, Host, Partner, NewsPost, BlogPost, Document, UrlDocument, Team, Content, Event, Milestone,
     Donation, BankAccount, ContactMessage, CycleDonation, FAQ, QuestionAndAnswer, UserRelation, JoinPage,
     SocialMediaLink, TeamUserRelation, CycleDonationRelation, Photo)
 from schedule.models.events import Event as ScheduleEvent
@@ -62,7 +62,7 @@ class DocumentTranslationOptions(TranslationOptions):
     fields = ('title','description')
 
 
-@register(ExternalDocument)
+@register(UrlDocument)
 class ExternalDocumentTranslationOptions(TranslationOptions):
     fields = ('title','description')
 

--- a/wbcore/views.py
+++ b/wbcore/views.py
@@ -620,6 +620,14 @@ def facts_view(request, host_slug=None):
     except Content.DoesNotExist:
         facts = None
 
+    financial_reports = Document.objects.filter(host=load_host, document_type='financial_report', public=True)
+    financial_reports_linked = LinkedDocument.objects.filter(host=load_host, document_type='financial_report', public=True)
+    financial_reports = join_documents_linked(financial_reports, financial_reports_linked, sort_key="-valid_from")
+
+    annual_reports = Document.objects.filter(host=load_host, document_type='annual_report', public=True)
+    annual_reports_linked = LinkedDocument.objects.filter(host=load_host, document_type='annual_report', public=True)
+    annual_reports = join_documents_linked(annual_reports, annual_reports_linked, sort_key="-valid_from")
+
     template = loader.get_template('wbcore/facts.html')
     context = {
         'main_nav': get_main_nav(host=host),
@@ -629,6 +637,8 @@ def facts_view(request, host_slug=None):
         'breadcrumb': breadcrumb,
         'icon_links': icon_links,
         'facts': facts,
+        'financial_reports': financial_reports,
+        'annual_reports': annual_reports,
     }
     return HttpResponse(template.render(context, request))
 

--- a/wbcore/views.py
+++ b/wbcore/views.py
@@ -436,7 +436,7 @@ def item_list_from_partners(partners, host_slug=None, text=True, max_num_items=N
     return item_list
 
 
-def join_documents_urldocuments(documents, url_documents, sort_key='valid_from'):
+def join_documents_urldocuments(documents, url_documents, sort_key='-valid_from'):
     documents = [d for d in documents]
     url_documents = [d for d in url_documents]
     documents = documents + url_documents
@@ -455,7 +455,6 @@ def home_view(request):
     news = NewsPost.objects.all().order_by('-published')[:5]
     blog = BlogPost.objects.all().order_by('-published')[:3]
     events = Event.objects.all().order_by('-start')
-
 
     template = loader.get_template('wbcore/home.html')
     context = {

--- a/wbcore/views.py
+++ b/wbcore/views.py
@@ -29,7 +29,7 @@ from honeypot.decorators import check_honeypot
 
 from wbcore.models import (
     Host, Project, Event, NewsPost, Location, BlogPost, Team, TeamUserRelation,
-    UserRelation, Partner, JoinPage, SocialMediaLink, Content, Document, UrlDocument, Donation, FAQ)
+    UserRelation, Partner, JoinPage, SocialMediaLink, Content, Document, LinkedDocument, Donation, FAQ)
 
 
 main_host_slug = 'bundesverband' ## TODO configure this?
@@ -436,10 +436,10 @@ def item_list_from_partners(partners, host_slug=None, text=True, max_num_items=N
     return item_list
 
 
-def join_documents_urldocuments(documents, url_documents, sort_key='-valid_from'):
+def join_documents_linked(documents, linked_documents, sort_key='-valid_from'):
     documents = [d for d in documents]
-    url_documents = [d for d in url_documents]
-    documents = documents + url_documents
+    linked_documents = [d for d in linked_documents]
+    documents = documents + linked_documents
     if sort_key[0] == '-':
         sort_reverse = True
         sort_key = sort_key[1:]
@@ -491,12 +491,12 @@ def reports_view(request, host_slug=None):
         report = None
 
     financial_reports = Document.objects.filter(host=load_host, document_type='financial_report', public=True)
-    financial_reports_url = UrlDocument.objects.filter(host=load_host, document_type='financial_report', public=True)
-    financial_reports = join_documents_urldocuments(financial_reports, financial_reports_url, sort_key="-valid_from")
+    financial_reports_linked = LinkedDocument.objects.filter(host=load_host, document_type='financial_report', public=True)
+    financial_reports = join_documents_linked(financial_reports, financial_reports_linked, sort_key="-valid_from")
 
     annual_reports = Document.objects.filter(host=load_host, document_type='annual_report', public=True)
-    annual_reports_url = UrlDocument.objects.filter(host=load_host, document_type='annual_report', public=True)
-    annual_reports = join_documents_urldocuments(annual_reports, annual_reports_url, sort_key="-valid_from")
+    annual_reports_linked = LinkedDocument.objects.filter(host=load_host, document_type='annual_report', public=True)
+    annual_reports = join_documents_linked(annual_reports, annual_reports_linked, sort_key="-valid_from")
 
     template = loader.get_template('wbcore/reports.html')
     context = {
@@ -531,8 +531,8 @@ def charter_view(request, host_slug=None):
         charter = None
 
     charter_files = Document.objects.filter(host=load_host, document_type='charter', public=True)
-    charter_files_url = UrlDocument.objects.filter(host=load_host, document_type='charter', public=True)
-    charter_files = join_documents_urldocuments(charter_files, charter_files_url, sort_key='-valid_from')
+    charter_linked = LinkedDocument.objects.filter(host=load_host, document_type='charter', public=True)
+    charter_files = join_documents_linked(charter_files, charter_linked, sort_key='-valid_from')
 
     template = loader.get_template('wbcore/charter.html')
     context = {
@@ -576,14 +576,12 @@ def transparency_view(request, host_slug=None):
     }
 
     financial_reports = Document.objects.filter(host=load_host, document_type='financial_report', public=True)
-    financial_reports_url = UrlDocument.objects.filter(host=load_host, document_type='financial_report', public=True)
-    financial_reports = join_documents_urldocuments(financial_reports, financial_reports_url, sort_key="-valid_from")
+    financial_reports_linked = LinkedDocument.objects.filter(host=load_host, document_type='financial_report', public=True)
+    financial_reports = join_documents_linked(financial_reports, financial_reports_linked, sort_key="-valid_from")
 
     annual_reports = Document.objects.filter(host=load_host, document_type='annual_report', public=True)
-    annual_reports_url = UrlDocument.objects.filter(host=load_host, document_type='annual_report', public=True)
-    annual_reports = join_documents_urldocuments(annual_reports, annual_reports_url, sort_key="-valid_from")
-
-
+    annual_reports_linked = LinkedDocument.objects.filter(host=load_host, document_type='annual_report', public=True)
+    annual_reports = join_documents_linked(annual_reports, annual_reports_linked, sort_key="-valid_from")
 
     template = loader.get_template('wbcore/transparency.html')
     context = {
@@ -1163,8 +1161,8 @@ def join_view(request, host_slug=None):
 
     if host:
         membership_declaration = Document.objects.filter(host=host, document_type='membership_declaration', public=True)
-        membership_declaration_url = UrlDocument.objects.filter(host=host, document_type='membership_declaration', public=True)
-        membership_declaration = join_documents_urldocuments(membership_declaration, membership_declaration_url, sort_key='-valid_from')
+        membership_declaration_linked = LinkedDocument.objects.filter(host=host, document_type='membership_declaration', public=True)
+        membership_declaration = join_documents_linked(membership_declaration, membership_declaration_linked, sort_key='-valid_from')
     else:
         membership_declaration = None
 

--- a/wbcore/views.py
+++ b/wbcore/views.py
@@ -29,7 +29,7 @@ from honeypot.decorators import check_honeypot
 
 from wbcore.models import (
     Host, Project, Event, NewsPost, Location, BlogPost, Team, TeamUserRelation,
-    UserRelation, Partner, JoinPage, SocialMediaLink, Content, Document, Donation, FAQ)
+    UserRelation, Partner, JoinPage, SocialMediaLink, Content, Document, ExternalDocument, Donation, FAQ)
 
 
 main_host_slug = 'bundesverband' ## TODO configure this?
@@ -436,6 +436,13 @@ def item_list_from_partners(partners, host_slug=None, text=True, max_num_items=N
     return item_list
 
 
+def join_documents_external(documents, external_documents):
+    documents = [d for d in documents]
+    external_documents = [d for d in external_documents]
+    documents = documents + external_documents
+    return sorted(documents, key=lambda x: x.valid_from, reverse=True)
+
+
 def home_view(request):
     projects = Project.objects.all()[:5]
     hosts = Host.objects.all()
@@ -479,8 +486,10 @@ def reports_view(request, host_slug=None):
         report = None
     financial_reports = Document.objects.filter(host=load_host, document_type='financial_report', public=True)
     financial_reports = financial_reports.order_by('-valid_from') if financial_reports else financial_reports
+
     annual_reports = Document.objects.filter(host=load_host, document_type='annual_report', public=True)
-    annual_reports = annual_reports.order_by('-valid_from') if annual_reports else annual_reports
+    annual_reports_ext = ExternalDocument.objects.filter(host=load_host, document_type='annual_report', public=True)
+    annual_reports = join_documents_external(annual_reports, annual_reports_ext)
 
     template = loader.get_template('wbcore/reports.html')
     context = {


### PR DESCRIPTION
# Beschreibung

Der Newsletter 2020 wurde nicht mehr als .pdf sondern als sway erstellt. Der Link zum Sway muss also eingebunden werden, damit der Jahresbericht weiter auf den Newsletter verweisen kann.

fixes #215 

## Typ

* Model Changes

## Änderungen

Das Model Document erbt jetzt von dem abstrakten Model BaseDocument. Zusätzlich wurde das Model LinkedDocument geschaffen, das ebenfalls von BaseDocument erbt aber eine url statt ein file enthällt.
